### PR TITLE
refactor: remove unused output_target configuration field

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Create a `config.toml` file:
 
 ```toml
 input_path = "data/input.parquet"
-output_target = "data/output.parquet"
 
 [[plugins]]
 name = "column-multiplier"

--- a/README_ja.md
+++ b/README_ja.md
@@ -104,7 +104,6 @@ nix develop ./dev
 
 ```toml
 input_path = "data/input.parquet"
-output_target = "data/output.parquet"
 
 [[plugins]]
 name = "column-multiplier"

--- a/docs/implements_step_plan.md
+++ b/docs/implements_step_plan.md
@@ -15,7 +15,7 @@ The project is divided into 4 phases for staged implementation.
 ### 1-2. Config Implementation (`cryoflow_core/config.py`)
 
 - `PluginConfig`: Pydantic model with name, module, enabled(=True), options(=dict)
-- `CryoflowConfig`: input_path(Path), output_target(str), plugins(list[PluginConfig])
+- `CryoflowConfig`: input_path(Path), plugins(list[PluginConfig])
 - `ConfigLoadError`: Exception wrapping file not found / TOML parse error / validation error
 - `get_default_config_path()`: Returns `xdg_config_home() / "cryoflow" / "config.toml"`
 - `load_config(config_path)`: Load TOML → Pydantic validation → return `CryoflowConfig`

--- a/docs/implements_step_plan_ja.md
+++ b/docs/implements_step_plan_ja.md
@@ -15,7 +15,7 @@
 ### 1-2. Config実装 (`cryoflow_core/config.py`)
 
 - `PluginConfig`: name, module, enabled(=True), options(=dict) の Pydantic モデル
-- `CryoflowConfig`: input_path(Path), output_target(str), plugins(list[PluginConfig])
+- `CryoflowConfig`: input_path(Path), plugins(list[PluginConfig])
 - `ConfigLoadError`: ファイル未検出 / TOMLパースエラー / バリデーションエラーをラップする例外
 - `get_default_config_path()`: `xdg_config_home() / "cryoflow" / "config.toml"` を返却
 - `load_config(config_path)`: TOML読み込み → Pydantic検証 → `CryoflowConfig` 返却

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -50,7 +50,6 @@ class PluginConfig(BaseModel):
 
 class CryoflowConfig(BaseModel):
     input_path: Path  # Use Path instead of FilePath to avoid enforcing file existence at config load time
-    output_target: str
     plugins: list[PluginConfig]
 ```
 
@@ -243,9 +242,8 @@ cryoflow run [-c CONFIG] [-v]
 
 ```
 Config loaded: /home/user/.config/cryoflow/config.toml
-  input_path:    data/input.parquet
-  output_target: data/output.parquet
-  plugins:       2 plugin(s)
+  input_path: data/input.parquet
+  plugins:    2 plugin(s)
     - transform_plugin (my.transform) [enabled]
     - output_plugin (my.output) [enabled]
 Loaded 2 plugin(s) successfully.

--- a/docs/spec_ja.md
+++ b/docs/spec_ja.md
@@ -53,7 +53,6 @@ class PluginConfig(BaseModel):
 
 class CryoflowConfig(BaseModel):
     input_path: Path  # FilePathだとファイル存在チェックが入るためPathを使用
-    output_target: str
     plugins: list[PluginConfig]
 ```
 
@@ -246,9 +245,8 @@ cryoflow run [-c CONFIG] [-v]
 
 ```
 Config loaded: /home/user/.config/cryoflow/config.toml
-  input_path:    data/input.parquet
-  output_target: data/output.parquet
-  plugins:       2 plugin(s)
+  input_path: data/input.parquet
+  plugins:    2 plugin(s)
     - transform_plugin (my.transform) [enabled]
     - output_plugin (my.output) [enabled]
 Loaded 2 plugin(s) successfully.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,5 +1,4 @@
 input_path = "examples/data/sample_sales.parquet"
-output_target = "examples/data/output.parquet"
 
 [[plugins]]
 name = "column-multiplier"

--- a/packages/cryoflow-core/cryoflow_core/cli.py
+++ b/packages/cryoflow-core/cryoflow_core/cli.py
@@ -66,9 +66,8 @@ def run(
         raise typer.Exit(code=1)
 
     typer.echo(f'Config loaded: {config_path}')
-    typer.echo(f'  input_path:    {cfg.input_path}')
-    typer.echo(f'  output_target: {cfg.output_target}')
-    typer.echo(f'  plugins:       {len(cfg.plugins)} plugin(s)')
+    typer.echo(f'  input_path: {cfg.input_path}')
+    typer.echo(f'  plugins:    {len(cfg.plugins)} plugin(s)')
     for plugin in cfg.plugins:
         status = 'enabled' if plugin.enabled else 'disabled'
         typer.echo(f'    - {plugin.name} ({plugin.module}) [{status}]')

--- a/packages/cryoflow-core/cryoflow_core/config.py
+++ b/packages/cryoflow-core/cryoflow_core/config.py
@@ -21,7 +21,6 @@ class CryoflowConfig(BaseModel):
     """Top-level configuration for cryoflow."""
 
     input_path: Path
-    output_target: str
     plugins: list[PluginConfig]
 
 

--- a/packages/cryoflow-core/tests/conftest.py
+++ b/packages/cryoflow-core/tests/conftest.py
@@ -80,7 +80,6 @@ class BrokenInitPlugin(TransformPlugin):
 
 VALID_TOML = """\
 input_path = "/data/input.parquet"
-output_target = "/data/output.parquet"
 
 [[plugins]]
 name = "my_plugin"
@@ -93,22 +92,20 @@ threshold = 42
 
 MINIMAL_TOML = """\
 input_path = "/data/input.parquet"
-output_target = "/data/output.parquet"
 plugins = []
 """
 
 INVALID_TOML_SYNTAX = """\
 input_path = "/data/input.parquet"
-output_target = /data/output  # missing quotes
+plugins = /invalid  # missing brackets
 """
 
 MISSING_FIELDS_TOML = """\
-output_target = "/data/output.parquet"
+plugins = []
 """
 
 MULTI_PLUGIN_TOML = """\
 input_path = "/data/input.parquet"
-output_target = "/data/output.parquet"
 
 [[plugins]]
 name = "plugin_a"

--- a/packages/cryoflow-core/tests/test_cli.py
+++ b/packages/cryoflow-core/tests/test_cli.py
@@ -83,23 +83,6 @@ class TestRunSuccess:
         assert 'input_path' in result.output
         assert '/data/input.parquet' in result.output
 
-    def test_output_contains_output_target(self, tmp_path):
-        config_file = tmp_path / 'config.toml'
-        config_file.write_text(VALID_TOML)
-
-        def mock_get_plugins(_pm, _plugin_type):
-            return []
-
-        with (
-            patch('cryoflow_core.cli.load_plugins') as mock_load,
-            patch('cryoflow_core.cli.get_plugins', side_effect=mock_get_plugins),
-        ):
-            mock_load.return_value = pluggy.PluginManager('cryoflow')
-            result = runner.invoke(app, ['run', '--config', str(config_file)])
-
-        assert 'output_target' in result.output
-        assert '/data/output.parquet' in result.output
-
     def test_output_contains_plugin_count(self, tmp_path):
         config_file = tmp_path / 'config.toml'
         config_file.write_text(VALID_TOML)
@@ -200,7 +183,6 @@ class TestDefaultConfigPath:
             with patch('cryoflow_core.cli.load_config') as mock_load_config:
                 mock_load_config.return_value = CryoflowConfig(
                     input_path=Path('/data/in.parquet'),
-                    output_target='/data/out.parquet',
                     plugins=[],
                 )
                 result = runner.invoke(app, ['run'])

--- a/packages/cryoflow-core/tests/test_config.py
+++ b/packages/cryoflow-core/tests/test_config.py
@@ -56,24 +56,14 @@ class TestCryoflowConfig:
     def test_valid(self):
         cfg = CryoflowConfig(
             input_path='/data/in.parquet',
-            output_target='/data/out.parquet',
             plugins=[PluginConfig(name='p', module='m')],
         )
         assert isinstance(cfg.input_path, Path)
-        assert cfg.output_target == '/data/out.parquet'
         assert len(cfg.plugins) == 1
 
     def test_missing_input_path(self):
         with pytest.raises(ValidationError):
             CryoflowConfig(
-                output_target='/data/out.parquet',
-                plugins=[],
-            )  # type: ignore[call-arg]
-
-    def test_missing_output_target(self):
-        with pytest.raises(ValidationError):
-            CryoflowConfig(
-                input_path='/data/in.parquet',
                 plugins=[],
             )  # type: ignore[call-arg]
 
@@ -81,7 +71,6 @@ class TestCryoflowConfig:
         with pytest.raises(ValidationError):
             CryoflowConfig(
                 input_path='/data/in.parquet',
-                output_target='/data/out.parquet',
             )  # type: ignore[call-arg]
 
 
@@ -108,7 +97,6 @@ class TestLoadConfig:
         cfg = load_config(valid_config_file)
         assert isinstance(cfg, CryoflowConfig)
         assert cfg.input_path == Path('/data/input.parquet')
-        assert cfg.output_target == '/data/output.parquet'
         assert len(cfg.plugins) == 1
         assert cfg.plugins[0].name == 'my_plugin'
         assert cfg.plugins[0].options == {'threshold': 42}

--- a/packages/cryoflow-core/tests/test_e2e.py
+++ b/packages/cryoflow-core/tests/test_e2e.py
@@ -150,7 +150,6 @@ class TestCheckCommand:
             config_file = Path(tmpdir) / 'config.toml'
             config_content = f"""\
 input_path = "{input_file}"
-output_target = "{tmpdir}/output.parquet"
 
 [[plugins]]
 name = "column_multiplier"
@@ -208,7 +207,6 @@ output_path = "{tmpdir}/output.parquet"
             config_file = Path(tmpdir) / 'config.toml'
             config_content = f"""\
 input_path = "{input_file}"
-output_target = "{tmpdir}/output.parquet"
 
 [[plugins]]
 name = "column_multiplier"
@@ -253,7 +251,6 @@ output_path = "{tmpdir}/output.parquet"
             config_file = Path(tmpdir) / 'config.toml'
             config_content = f"""\
 input_path = "{input_file}"
-output_target = "{tmpdir}/output.parquet"
 
 [[plugins]]
 name = "column_multiplier"

--- a/packages/cryoflow-core/tests/test_loader.py
+++ b/packages/cryoflow-core/tests/test_loader.py
@@ -304,9 +304,9 @@ class TestPluginHookRelay:
 
 class TestLoadPlugins:
     def _make_config(self, plugins: list[PluginConfig]) -> CryoflowConfig:
+        from pathlib import Path
         return CryoflowConfig(
             input_path=Path('/data/in.parquet'),
-            output_target='/data/out.parquet',
             plugins=plugins,
         )
 


### PR DESCRIPTION
## Summary
Remove the unused `output_target` configuration field from `CryoflowConfig` model. This field was defined in the configuration but was not actually used in the implementation.

## Changes
- Remove `output_target` field from `CryoflowConfig` Pydantic model
- Update documentation (specs, implementation plan, README)
- Update example configuration files
- Remove related test cases and update remaining tests
- Update CLI output display logic

## Impact
- **Breaking Change**: Users must remove the `output_target` line from their `config.toml` files
- Configuration files are now simpler and more accurate to actual functionality
- Output path is now specified in individual output plugin configurations where it belongs

## Test Plan
- All existing tests pass with the removed field
- Configuration loading works correctly without `output_target`